### PR TITLE
Equipping addon and inventory fix

### DIFF
--- a/items.py
+++ b/items.py
@@ -11,6 +11,7 @@ class item(object):
 class weapon(item):
     def __init__(self, name, description, value, damage):
         self.damage = damage
+        self.equipped_as_weapon = False
         super(weapon, self).__init__(name, description, value)
     def observe(self):
         return "{}\n-----\n{}\nValue: {}\nDamage: {}\n".format(self.name, self.description, self.value, self.damage)
@@ -28,13 +29,23 @@ class healing_consumable(item):
 class armour(item):
     def __init__(self, name, description, value, armour_value):
         self.armour_value = armour_value
+        self.equipped_as_armour = False
         super(armour, self).__init__(name, description, value)
+    def equip_armour(self):
+        for armour in player.inventory:
+            armour.equipped_as_armour = False
+        self.equipped_as_armour = True
     def observe(self):
         return "{}\n-----\n{}\nValue: {}\nArmour: {}\n".format(self.name, self.description, self.value, self.armour_value)
 
 class shield(item):
     def __init__(self, name, description, value, block_value):
         self.block_value = block_value
+        self.equipped_as_shield = False
         super(shield, self).__init__(name, description, value)
+    def equip_shield(self):
+        for shield in player.inventory:
+            shield.equipped_as_shield = False
+        self.equipped_as_shield = True
     def observe(self):
         return "{}\n-----\n{}\nValue: {}\nBlock: {}\n".format(self.name, self.description, self.value, self.block_value)

--- a/items.py
+++ b/items.py
@@ -31,10 +31,6 @@ class armour(item):
         self.armour_value = armour_value
         self.equipped_as_armour = False
         super(armour, self).__init__(name, description, value)
-    def equip_armour(self):
-        for armour in player.inventory:
-            armour.equipped_as_armour = False
-        self.equipped_as_armour = True
     def observe(self):
         return "{}\n-----\n{}\nValue: {}\nArmour: {}\n".format(self.name, self.description, self.value, self.armour_value)
 
@@ -43,9 +39,5 @@ class shield(item):
         self.block_value = block_value
         self.equipped_as_shield = False
         super(shield, self).__init__(name, description, value)
-    def equip_shield(self):
-        for shield in player.inventory:
-            shield.equipped_as_shield = False
-        self.equipped_as_shield = True
     def observe(self):
         return "{}\n-----\n{}\nValue: {}\nBlock: {}\n".format(self.name, self.description, self.value, self.block_value)

--- a/player.py
+++ b/player.py
@@ -1,11 +1,63 @@
+import items
+
 class player():
     def __init__(self, inventory):
         self.inventory = inventory
         self.hp = 100
-#         self.location = world.starting_location
+#         self.location_x, self.location_y = world.starting_location
         self.victory = False
+
     def is_not_dead(self):
         return self.hp > 0
+
     def take_inventory(self):
+        return '\n'.join('{}'.format(item) for item in self.inventory)
+
+    def equip_weapon(self, weapon_to_be_equipped):
         for item in self.inventory:
-            return "{} \n".format(item)
+            if type(item) is items.weapon:
+                item.equipped_as_weapon = False
+        weapon_to_be_equipped.equipped_as_weapon = True
+
+    def equip_armour(self, armour_to_be_equipped):
+        for item in self.inventory:
+            if type(item) is items.armour:
+                item.equipped_as_armour = False
+        armour_to_be_equipped.equipped_as_armour = True
+
+    def equip_shield(self, shield_to_be_equipped):
+        for item in self.inventory:
+            if type(item) is items.shield:
+                item.equipped_as_shield = False
+        shield_to_be_equipped.equipped_as_shield = True
+
+    def view_equipped_items(self):
+        equipped_items = []
+        for item in self.inventory:
+            if type(item) is items.weapon:
+                if item.equipped_as_weapon == True:
+                    equipped_items.append("{} equipped as weapon.".format(item))
+            if type(item) is items.armour:
+                if item.equipped_as_armour == True:
+                    equipped_items.append("{} equipped as armour.".format(item))
+            if type(item) is items.shield:
+                if item.equipped_as_shield == True:
+                    equipped_items.append("{} equipped as shield.".format(item))
+        return '\n'.join('{}'.format(item) for item in equipped_items)
+
+    def move(self, dx, dy):
+        self.location_x += dx
+        self.location_y += dy
+        return world.tile_exists(self.location_x, self.location_y).intro_text()
+
+    def move_north(self):
+        self.move(dx=0, dy=-1)
+
+    def move_south(self):
+        self.move(dx=0, dy=1)
+
+    def move_east(self):
+        self.move(dx=1, dy=0)
+
+    def move_west(self):
+        self.move(dx=-1, dy=0)

--- a/player.py
+++ b/player.py
@@ -45,19 +45,19 @@ class player():
                     equipped_items.append("{} equipped as shield.".format(item))
         return '\n'.join('{}'.format(item) for item in equipped_items)
 
-    def move(self, dx, dy):
-        self.location_x += dx
-        self.location_y += dy
-        return world.tile_exists(self.location_x, self.location_y).intro_text()
+#     def move(self, dx, dy):
+#         self.location_x += dx
+#         self.location_y += dy
+#         return world.tile_exists(self.location_x, self.location_y).intro_text()
 
-    def move_north(self):
-        self.move(dx=0, dy=-1)
+#     def move_north(self):
+#         self.move(dx=0, dy=-1)
 
-    def move_south(self):
-        self.move(dx=0, dy=1)
+#     def move_south(self):
+#         self.move(dx=0, dy=1)
 
-    def move_east(self):
-        self.move(dx=1, dy=0)
+#     def move_east(self):
+#         self.move(dx=1, dy=0)
 
-    def move_west(self):
-        self.move(dx=-1, dy=0)
+#     def move_west(self):
+#         self.move(dx=-1, dy=0)


### PR DESCRIPTION
 Turns out the inventory function was no longer return the right output after I changed it to output a string so that has been fixed. Meanwhile considerable expansion to items and player functions that adds 'equipping' functionality - weapons now have an 'is equipped as weapon' flag and so on while the player has a function that equips items in their inventory and also one that shows the items that they have equipped. A player can only have one weapon, armour and shield equipped at one time. The combat should now use the items that are equipped rather than the best items in the inventory.